### PR TITLE
add iteratePrefixes, scanWithTotal, and filtermap

### DIFF
--- a/lib/github.com/mpllang/mpllib/ArraySequence.sml
+++ b/lib/github.com/mpllang/mpllib/ArraySequence.sml
@@ -122,6 +122,16 @@ struct
     SeqBasis.foldl f b (0, length s) (nth s)
 
 
+  fun iteratePrefixes f b s =
+    let 
+      let 
+        fun g (l, b) a = (b::l, f(b, a))
+        val (l, r) = iterate g ([], b) s
+      in 
+        fromList (List.rev l, r)
+      end
+
+
   fun reduce f b s =
     SeqBasis.reduce GRAN f b (0, length s) (nth s)
 
@@ -133,6 +143,8 @@ struct
       (take p (length s), nth p (length s))
     end
 
+  fun scanWithTotal f b s =
+    AS.full (SeqBasis.scan GRAN f b (0, length s) (nth s))
 
   fun scanIncl f b s =
     let
@@ -148,6 +160,9 @@ struct
 
   fun filterIdx p s =
     AS.full (SeqBasis.filter GRAN (0, length s) (nth s) (fn i => p (i, nth s i)))
+
+  fun filtermap (f:'a -> 'b) (p: 'a -> bool) (s: 'a t): 'b t =
+     AS.full (SeqBasis.filter GRAN (0, length s) (fn i => f (nth s i)) (p o nth s))
 
 
   fun mapOption f s =

--- a/lib/github.com/mpllang/mpllib/ArraySequence.sml
+++ b/lib/github.com/mpllang/mpllib/ArraySequence.sml
@@ -29,7 +29,6 @@ struct
   type 'a t = 'a AS.t
   type 'a seq = 'a t
 
-
   (* for compatibility across all sequence implementations *)
   fun fromArraySeq s = s
   fun toArraySeq s = s
@@ -39,12 +38,16 @@ struct
   val nth = AS.nth
   val length = AS.length
 
-
   fun empty () = AS.full (A.fromList [])
   fun singleton x = AS.full (A.array (1, x))
   val $ = singleton
   fun toString f s =
     "<" ^ String.concatWith "," (List.tabulate (length s, f o nth s)) ^ ">"
+
+
+  fun fromArray a = AS.full a
+
+
   fun fromList l = AS.full (A.fromList l)
   val % = fromList
   fun toList s =

--- a/lib/github.com/mpllang/mpllib/ArraySequence.sml
+++ b/lib/github.com/mpllang/mpllib/ArraySequence.sml
@@ -158,8 +158,12 @@ struct
 
 
   fun filter p s =
+    (* Assumes that the predicate p is pure *)
     AS.full (SeqBasis.filter GRAN (0, length s) (nth s) (p o nth s))
 
+  fun filterSafe p s = 
+    (* Does not assume that the predicate p is pure *)
+    AS.full (SeqBasis.tabFilter GRAN (0, length s) (fn i => if p (nth s i) then SOME (nth s i) else NONE))
 
   fun filterIdx p s =
     AS.full (SeqBasis.filter GRAN (0, length s) (nth s) (fn i => p (i, nth s i)))

--- a/lib/github.com/mpllang/mpllib/ArraySequence.sml
+++ b/lib/github.com/mpllang/mpllib/ArraySequence.sml
@@ -122,6 +122,12 @@ struct
     end
 
 
+  fun foldl f b s =
+    SeqBasis.foldl f b (0, length s) (nth s)
+
+  fun foldr f b s =
+    SeqBasis.foldr f b (~1, length s-1) (nth s)
+
   fun iterate f b s =
     SeqBasis.foldl f b (0, length s) (nth s)
 

--- a/lib/github.com/mpllang/mpllib/ArraySequence.sml
+++ b/lib/github.com/mpllang/mpllib/ArraySequence.sml
@@ -161,7 +161,7 @@ struct
   fun filterIdx p s =
     AS.full (SeqBasis.filter GRAN (0, length s) (nth s) (fn i => p (i, nth s i)))
 
-  fun filtermap (f:'a -> 'b) (p: 'a -> bool) (s: 'a t): 'b t =
+  fun filtermap (p: 'a -> bool) (f:'a -> 'b) (s: 'a t): 'b t =
      AS.full (SeqBasis.filter GRAN (0, length s) (fn i => f (nth s i)) (p o nth s))
 
 

--- a/lib/github.com/mpllang/mpllib/ArraySequence.sml
+++ b/lib/github.com/mpllang/mpllib/ArraySequence.sml
@@ -126,7 +126,7 @@ struct
     SeqBasis.foldl f b (0, length s) (nth s)
 
   fun foldr f b s =
-    SeqBasis.foldr f b (~1, length s-1) (nth s)
+    SeqBasis.foldr f b (0, length s) (nth s)
 
   fun iterate f b s =
     SeqBasis.foldl f b (0, length s) (nth s)

--- a/lib/github.com/mpllang/mpllib/ArraySequence.sml
+++ b/lib/github.com/mpllang/mpllib/ArraySequence.sml
@@ -59,7 +59,8 @@ struct
     AS.subslice (s, i, SOME k)
   fun take s n = subseq s (0, n)
   fun drop s n = subseq s (n, length s - n)
-
+  fun first s = nth s 0
+  fun last s = nth s (length s - 1)
 
   fun tabulate f n =
     AS.full (SeqBasis.tabulate GRAN (0, n) f)
@@ -127,12 +128,17 @@ struct
 
   fun iteratePrefixes f b s =
     let 
-      let 
-        fun g (l, b) a = (b::l, f(b, a))
-        val (l, r) = iterate g ([], b) s
-      in 
-        fromList (List.rev l, r)
-      end
+      val prefixes = alloc (length s)
+      fun g ((i, b), a) = 
+        let 
+          val _ = A.update (prefixes, i, b)
+        in
+          (i+1, f (b, a))
+        end
+      val (_, r) = iterate g (0, b) s
+    in 
+        (AS.full prefixes, r)
+    end
 
 
   fun reduce f b s =

--- a/lib/github.com/mpllang/mpllib/SeqBasis.sml
+++ b/lib/github.com/mpllang/mpllib/SeqBasis.sml
@@ -10,6 +10,12 @@ sig
           -> (int -> 'a)
           -> 'b
 
+  val foldr: ('b * 'a -> 'b)
+          -> 'b
+          -> (int * int)
+          -> (int -> 'a)
+          -> 'b
+
   val reduce: grain
            -> ('a * 'a -> 'a)
            -> 'a
@@ -73,6 +79,14 @@ struct
       val b' = g (b, f lo)
     in
       foldl g b' (lo+1, hi) f
+    end
+
+  fun foldr g b (lo, hi) f =
+    if lo >= hi then b else
+    let
+      val b' = g (b, f hi)
+    in
+      foldr g b' (lo, hi-1) f
     end
 
   fun reduce grain g b (lo, hi) f =

--- a/lib/github.com/mpllang/mpllib/SeqBasis.sml
+++ b/lib/github.com/mpllang/mpllib/SeqBasis.sml
@@ -82,11 +82,12 @@ struct
     end
 
   fun foldr g b (lo, hi) f =
-    if lo >= hi then b else
+    if lo > hi then b else
     let
-      val b' = g (b, f hi)
+      val hi' = hi-1
+      val b' = g (b, f hi')
     in
-      foldr g b' (lo, hi-1) f
+      foldr g b' (lo, hi') f
     end
 
   fun reduce grain g b (lo, hi) f =


### PR DESCRIPTION
Add several functions to sequences
* `iteratePrefixes`: keep prefix sums (as in scan, basically sequential version of scan)
* `scanWithTotal`: return n+1 size sequence where the last element is the total
* `filtermap`: filter and then map, fused application
* `filterSafe`: does not assume that the predicate is pure
* `fromArray`
* `first, last`: return first and last elt of sequence