### PR TITLE
fix off-by-one error in `foldr`

### DIFF
--- a/lib/github.com/mpllang/mpllib/SeqBasis.sml
+++ b/lib/github.com/mpllang/mpllib/SeqBasis.sml
@@ -82,7 +82,7 @@ struct
     end
 
   fun foldr g b (lo, hi) f =
-    if lo > hi then b else
+    if lo >= hi then b else
     let
       val hi' = hi-1
       val b' = g (b, f hi')


### PR DESCRIPTION
The previous code accessed `f(lo-1)` which is outside the range. This fixes that.

A good litmus test is to check for `foldr g b (lo, hi) f == foldl g b (lo, hi) f` when `g` is associative.

For example, with the old code (buggy):
```
Standard ML of New Jersey v110.79
- foldl op* 1 (1, 5) (fn i => i);
val it = 24 : int
- foldr op* 1 (1, 5) (fn i => i);
val it = 0 : int
```

And new code (fixed):
```
Standard ML of New Jersey v110.79
- foldl op* 1 (1, 5) (fn i => i);
val it = 24 : int
- foldr op* 1 (1, 5) (fn i => i);
val it = 24 : int
```