### PR TITLE
Low-span parallel merge

### DIFF
--- a/lib/github.com/mpllang/mpllib/DoubleBinarySearch.sml
+++ b/lib/github.com/mpllang/mpllib/DoubleBinarySearch.sml
@@ -1,0 +1,123 @@
+(* The function `split_count` splits sequences s and t into (s1, s2) and
+ * (t1, t2) such that the largest items of s1 and t1 are smaller than the
+ * smallest items of s2 and t2. The desired output size |s1|+|t1| is given
+ * as a parameter.
+ *
+ * Specifically, `split_count cmp (s, t) k` returns `(m, n)` where:
+ *   (s1, s2) = (s[..m], s[m..])
+ *   (t1, t2) = (t[..n], t[n..])
+ *   m+n = k
+ *   max(s1) <= min(t2)
+ *   max(t1) <= min(s2)
+ *
+ * Note that there are many possible solutions, so we also mandate that `m`
+ * should be minimized.
+ *
+ * Work: O(log(|s|+|t|))
+ * Span: O(log(|s|+|t|))
+ *)
+structure DoubleBinarySearch:
+sig
+  type 'a seq = {lo: int, hi: int, get: int -> 'a}
+
+  val split_count: ('a * 'a -> order) -> 'a seq * 'a seq -> int -> (int * int)
+
+  val split_count_slice: ('a * 'a -> order)
+                         -> 'a ArraySlice.slice * 'a ArraySlice.slice
+                         -> int
+                         -> (int * int)
+end =
+struct
+
+  type 'a seq = {lo: int, hi: int, get: int -> 'a}
+
+  fun leq cmp (x, y) =
+    case cmp (x, y) of
+      GREATER => false
+    | _ => true
+
+  fun geq cmp (x, y) =
+    case cmp (x, y) of
+      LESS => false
+    | _ => true
+
+  fun split_count cmp (s: 'a seq, t: 'a seq) k =
+    let
+      fun normalize_then_loop (slo, shi) (tlo, thi) count =
+        let
+          val slo_orig = slo
+          val tlo_orig = tlo
+
+          (* maybe count is small *)
+          val shi = Int.min (shi, slo + count)
+          val thi = Int.min (thi, tlo + count)
+
+          (* maybe count is large *)
+          val slack = (shi - slo) + (thi - tlo) - count
+          val slack = Int.min (slack, shi - slo)
+          val slack = Int.min (slack, thi - tlo)
+
+          val slo = Int.max (slo, shi - slack)
+          val tlo = Int.max (tlo, thi - slack)
+
+          val count = count - (slo - slo_orig) - (tlo - tlo_orig)
+        in
+          loop (slo, shi) (tlo, thi) count
+        end
+
+
+      and loop (slo, shi) (tlo, thi) count =
+        if shi - slo <= 0 then
+          (slo, tlo + count)
+
+        else if thi - tlo <= 0 then
+          (slo + count, tlo)
+
+        else if count = 1 then
+          if geq cmp (#get s slo, #get t tlo) then (slo, tlo + 1)
+          else (slo + 1, tlo)
+
+        else
+          let
+            val m = count div 2
+            val n = count - m
+
+            (*  |------|x|-------|
+             *  ^      ^         ^
+             * slo   slo+m      shi
+             *
+             *  |------|y|-------|
+             *  ^        ^       ^
+             * tlo     tlo+n    thi
+             *)
+
+            val leq_y_x =
+              n = 0 orelse slo + m >= shi
+              orelse leq cmp (#get t (tlo + n - 1), #get s (slo + m))
+          in
+            if leq_y_x then
+              normalize_then_loop (slo, shi) (tlo + n, thi) (count - n)
+            else
+              normalize_then_loop (slo, shi) (tlo, tlo + n) count
+          end
+
+
+      val {lo = slo, hi = shi, ...} = s
+      val {lo = tlo, hi = thi, ...} = t
+
+      val (m, n) = normalize_then_loop (slo, shi) (tlo, thi) k
+    in
+      (m - slo, n - tlo)
+    end
+
+
+  fun fromslice s =
+    let val (sarr, slo, slen) = ArraySlice.base s
+    in {lo = slo, hi = slo + slen, get = fn i => Array.sub (sarr, i)}
+    end
+
+
+  fun split_count_slice cmp (s, t) k =
+    split_count cmp (fromslice s, fromslice t) k
+
+end

--- a/lib/github.com/mpllang/mpllib/Merge.sml
+++ b/lib/github.com/mpllang/mpllib/Merge.sml
@@ -2,17 +2,15 @@ structure Merge:
 sig
   type 'a seq = 'a ArraySlice.slice
 
-  val writeMergeSerial:
-       ('a * 'a -> order)   (* compare *)
-    -> 'a seq * 'a seq      (* (sorted) sequences to merge *)
-    -> 'a seq               (* output *)
-    -> unit
+  val writeMergeSerial: ('a * 'a -> order) (* compare *)
+                        -> 'a seq * 'a seq (* (sorted) sequences to merge *)
+                        -> 'a seq (* output *)
+                        -> unit
 
-  val writeMerge:
-       ('a * 'a -> order)   (* compare *)
-    -> 'a seq * 'a seq      (* (sorted) sequences to merge *)
-    -> 'a seq               (* output *)
-    -> unit
+  val writeMerge: ('a * 'a -> order) (* compare *)
+                  -> 'a seq * 'a seq (* (sorted) sequences to merge *)
+                  -> 'a seq (* output *)
+                  -> unit
 
   val mergeSerial: ('a * 'a -> order) -> 'a seq * 'a seq -> 'a seq
   val merge: ('a * 'a -> order) -> 'a seq * 'a seq -> 'a seq
@@ -27,7 +25,10 @@ struct
   val par = ForkJoin.par
   val allocate = ForkJoin.alloc
 
-  fun sliceIdxs s i j = AS.subslice (s, i, SOME (j-i))
+  val serialGrain = CommandLineArgs.parseInt "MPLLib_Merge_serialGrain" 4000
+
+  fun sliceIdxs s i j =
+    AS.subslice (s, i, SOME (j - i))
 
   fun writeMergeSerial cmp (s1, s2) t =
     let
@@ -41,32 +42,29 @@ struct
        * j index into output *)
       fun loop i1 i2 j =
         if i1 = n1 then
-          Util.foreach (sliceIdxs s2 i2 n2) (fn (i, x) => write (i+j) x)
+          Util.foreach (sliceIdxs s2 i2 n2) (fn (i, x) => write (i + j) x)
         else if i2 = n2 then
-          Util.foreach (sliceIdxs s1 i1 n1) (fn (i, x) => write (i+j) x)
+          Util.foreach (sliceIdxs s1 i1 n1) (fn (i, x) => write (i + j) x)
         else
           let
             val x1 = AS.sub (s1, i1)
             val x2 = AS.sub (s2, i2)
           in
             case cmp (x1, x2) of
-              LESS => (write j x1; loop (i1+1) i2 (j+1))
-            | _    => (write j x2; loop i1 (i2+1) (j+1))
+              LESS => (write j x1; loop (i1 + 1) i2 (j + 1))
+            | _ => (write j x2; loop i1 (i2 + 1) (j + 1))
           end
     in
       loop 0 0 0
     end
 
   fun mergeSerial cmp (s1, s2) =
-    let
-      val out = AS.full (allocate (AS.length s1 + AS.length s2))
-    in
-      writeMergeSerial cmp (s1, s2) out;
-      out
+    let val out = AS.full (allocate (AS.length s1 + AS.length s2))
+    in writeMergeSerial cmp (s1, s2) out; out
     end
 
   fun writeMerge cmp (s1, s2) t =
-    if AS.length t <= 4096 then
+    if AS.length t <= serialGrain then
       writeMergeSerial cmp (s1, s2) t
     else if AS.length s1 = 0 then
       Util.foreach s2 (fn (i, x) => AS.update (t, i, x))
@@ -79,25 +77,22 @@ struct
         val mid2 = BinarySearch.search cmp s2 pivot
 
         val l1 = sliceIdxs s1 0 mid1
-        val r1 = sliceIdxs s1 (mid1+1) n1
+        val r1 = sliceIdxs s1 (mid1 + 1) n1
         val l2 = sliceIdxs s2 0 mid2
         val r2 = sliceIdxs s2 mid2 n2
 
-        val _ = AS.update (t, mid1+mid2, pivot)
-        val tl = sliceIdxs t 0 (mid1+mid2)
-        val tr = sliceIdxs t (mid1+mid2+1) (AS.length t)
+        val _ = AS.update (t, mid1 + mid2, pivot)
+        val tl = sliceIdxs t 0 (mid1 + mid2)
+        val tr = sliceIdxs t (mid1 + mid2 + 1) (AS.length t)
       in
-        par (fn _ => writeMerge cmp (l1, l2) tl,
-             fn _ => writeMerge cmp (r1, r2) tr);
+        par (fn _ => writeMerge cmp (l1, l2) tl, fn _ =>
+          writeMerge cmp (r1, r2) tr);
         ()
       end
 
   fun merge cmp (s1, s2) =
-    let
-      val out = AS.full (allocate (AS.length s1 + AS.length s2))
-    in
-      writeMerge cmp (s1, s2) out;
-      out
+    let val out = AS.full (allocate (AS.length s1 + AS.length s2))
+    in writeMerge cmp (s1, s2) out; out
     end
 
 end

--- a/lib/github.com/mpllang/mpllib/StableMerge.sml
+++ b/lib/github.com/mpllang/mpllib/StableMerge.sml
@@ -2,17 +2,15 @@ structure StableMerge:
 sig
   type 'a seq = 'a ArraySlice.slice
 
-  val writeMergeSerial:
-       ('a * 'a -> order)   (* compare *)
-    -> 'a seq * 'a seq      (* (sorted) sequences to merge *)
-    -> 'a seq               (* output *)
-    -> unit
+  val writeMergeSerial: ('a * 'a -> order) (* compare *)
+                        -> 'a seq * 'a seq (* (sorted) sequences to merge *)
+                        -> 'a seq (* output *)
+                        -> unit
 
-  val writeMerge:
-       ('a * 'a -> order)   (* compare *)
-    -> 'a seq * 'a seq      (* (sorted) sequences to merge *)
-    -> 'a seq               (* output *)
-    -> unit
+  val writeMerge: ('a * 'a -> order) (* compare *)
+                  -> 'a seq * 'a seq (* (sorted) sequences to merge *)
+                  -> 'a seq (* output *)
+                  -> unit
 
   val mergeSerial: ('a * 'a -> order) -> 'a seq * 'a seq -> 'a seq
   val merge: ('a * 'a -> order) -> 'a seq * 'a seq -> 'a seq
@@ -27,7 +25,11 @@ struct
   val par = ForkJoin.par
   val allocate = ForkJoin.alloc
 
-  fun sliceIdxs s i j = AS.subslice (s, i, SOME (j-i))
+  val serialGrain =
+    CommandLineArgs.parseInt "MPLLib_StableMerge_serialGrain" 4000
+
+  fun sliceIdxs s i j =
+    AS.subslice (s, i, SOME (j - i))
 
   fun writeMergeSerial cmp (s1, s2) t =
     let
@@ -41,9 +43,9 @@ struct
        * j index into output *)
       fun loop i1 i2 j =
         if i1 = n1 then
-          Util.foreach (sliceIdxs s2 i2 n2) (fn (i, x) => write (i+j) x)
+          Util.foreach (sliceIdxs s2 i2 n2) (fn (i, x) => write (i + j) x)
         else if i2 = n2 then
-          Util.foreach (sliceIdxs s1 i1 n1) (fn (i, x) => write (i+j) x)
+          Util.foreach (sliceIdxs s1 i1 n1) (fn (i, x) => write (i + j) x)
         else
           let
             val x1 = AS.sub (s1, i1)
@@ -51,23 +53,20 @@ struct
           in
             (* NOTE: this is stable *)
             case cmp (x1, x2) of
-              GREATER => (write j x2; loop i1 (i2+1) (j+1))
-            | _       => (write j x1; loop (i1+1) i2 (j+1))
+              GREATER => (write j x2; loop i1 (i2 + 1) (j + 1))
+            | _ => (write j x1; loop (i1 + 1) i2 (j + 1))
           end
     in
       loop 0 0 0
     end
 
   fun mergeSerial cmp (s1, s2) =
-    let
-      val out = AS.full (allocate (AS.length s1 + AS.length s2))
-    in
-      writeMergeSerial cmp (s1, s2) out;
-      out
+    let val out = AS.full (allocate (AS.length s1 + AS.length s2))
+    in writeMergeSerial cmp (s1, s2) out; out
     end
 
   fun writeMerge cmp (s1, s2) t =
-    if AS.length t <= 4096 then
+    if AS.length t <= serialGrain then
       writeMergeSerial cmp (s1, s2) t
     else if AS.length s1 = 0 then
       Util.foreach s2 (fn (i, x) => AS.update (t, i, x))
@@ -80,25 +79,22 @@ struct
         val mid2 = BinarySearch.countLess cmp s2 pivot
 
         val l1 = sliceIdxs s1 0 mid1
-        val r1 = sliceIdxs s1 (mid1+1) n1
+        val r1 = sliceIdxs s1 (mid1 + 1) n1
         val l2 = sliceIdxs s2 0 mid2
         val r2 = sliceIdxs s2 mid2 n2
 
-        val _ = AS.update (t, mid1+mid2, pivot)
-        val tl = sliceIdxs t 0 (mid1+mid2)
-        val tr = sliceIdxs t (mid1+mid2+1) (AS.length t)
+        val _ = AS.update (t, mid1 + mid2, pivot)
+        val tl = sliceIdxs t 0 (mid1 + mid2)
+        val tr = sliceIdxs t (mid1 + mid2 + 1) (AS.length t)
       in
-        par (fn _ => writeMerge cmp (l1, l2) tl,
-             fn _ => writeMerge cmp (r1, r2) tr);
+        par (fn _ => writeMerge cmp (l1, l2) tl, fn _ =>
+          writeMerge cmp (r1, r2) tr);
         ()
       end
 
   fun merge cmp (s1, s2) =
-    let
-      val out = AS.full (allocate (AS.length s1 + AS.length s2))
-    in
-      writeMerge cmp (s1, s2) out;
-      out
+    let val out = AS.full (allocate (AS.length s1 + AS.length s2))
+    in writeMerge cmp (s1, s2) out; out
     end
 
 end

--- a/lib/github.com/mpllang/mpllib/StableMergeLowSpan.sml
+++ b/lib/github.com/mpllang/mpllib/StableMergeLowSpan.sml
@@ -30,7 +30,7 @@ struct
 
 
   val blockSizeFactor =
-    CommandLineArgs.parseReal "MPLLib_MergeLowSpan_blockSizeFactor" 100.0
+    CommandLineArgs.parseReal "MPLLib_StableMergeLowSpan_blockSizeFactor" 100.0
 
 
   fun log2 x =

--- a/lib/github.com/mpllang/mpllib/StableMergeLowSpan.sml
+++ b/lib/github.com/mpllang/mpllib/StableMergeLowSpan.sml
@@ -1,0 +1,75 @@
+structure StableMergeLowSpan:
+sig
+  type 'a seq = 'a ArraySlice.slice
+
+  val writeMerge: ('a * 'a -> order) (* compare *)
+                  -> 'a seq * 'a seq (* (sorted) sequences to merge *)
+                  -> 'a seq (* output *)
+                  -> unit
+
+  val merge: ('a * 'a -> order) -> 'a seq * 'a seq -> 'a seq
+end =
+struct
+
+  structure AS = ArraySlice
+  type 'a seq = 'a AS.slice
+  fun slice_idxs s (i, j) =
+    AS.subslice (s, i, SOME (j - i))
+
+
+  (* DoubleBinarySearch guarantees that it takes the _minimum_ number of
+   * elements from the first argument. For stability, we want to take the
+   * _maximum_ number of elements from s1; this is equivalent to taking the
+   * minimum from s2. So, we can just swap the order of the arguments we
+   * give to the search.
+   *)
+  fun split_count_take_max_left cmp (s1, s2) k =
+    let val (i2, i1) = DoubleBinarySearch.split_count_slice cmp (s2, s1) k
+    in (i1, i2)
+    end
+
+
+  val blockSizeFactor =
+    CommandLineArgs.parseReal "MPLLib_MergeLowSpan_blockSizeFactor" 100.0
+
+
+  fun log2 x =
+    Real64.Math.log10 (Real64.fromInt x) / Real64.Math.log10 2.0
+
+
+  fun writeMerge cmp (s1, s2) output =
+    let
+      val n = AS.length s1 + AS.length s2
+      val logn = if n <= 2 then 1.0 else log2 n
+      val blockSize = Real64.ceil (blockSizeFactor * logn)
+      val numBlocks = Util.ceilDiv n blockSize
+    in
+      ForkJoin.parfor 1 (0, numBlocks) (fn b =>
+        let
+          val start = blockSize * b
+          val stop = Int.min (n, start + blockSize)
+
+          val (i1, i2) = split_count_take_max_left cmp (s1, s2) start
+          val (j1, j2) = split_count_take_max_left cmp (s1, s2) stop
+
+          (* val _ = print
+            ("block " ^ Int.toString b ^ " start " ^ Int.toString start
+             ^ " stop " ^ Int.toString stop ^ " i1 " ^ Int.toString i1 ^ " j1 "
+             ^ Int.toString j1 ^ " i2 " ^ Int.toString i2 ^ " j2 "
+             ^ Int.toString j2 ^ "\n") *)
+
+          val piece1 = slice_idxs s1 (i1, j1)
+          val piece2 = slice_idxs s2 (i2, j2)
+          val piece_output = slice_idxs output (start, stop)
+        in
+          StableMerge.writeMergeSerial cmp (piece1, piece2) piece_output
+        end)
+    end
+
+
+  fun merge cmp (s1, s2) =
+    let val out = AS.full (ForkJoin.alloc (AS.length s1 + AS.length s2))
+    in writeMerge cmp (s1, s2) out; out
+    end
+
+end

--- a/lib/github.com/mpllang/mpllib/StableMergeLowSpan.sml
+++ b/lib/github.com/mpllang/mpllib/StableMergeLowSpan.sml
@@ -30,7 +30,7 @@ struct
 
 
   val blockSizeFactor =
-    CommandLineArgs.parseReal "MPLLib_StableMergeLowSpan_blockSizeFactor" 100.0
+    CommandLineArgs.parseReal "MPLLib_StableMergeLowSpan_blockSizeFactor" 1000.0
 
 
   fun log2 x =
@@ -52,17 +52,11 @@ struct
           val (i1, i2) = split_count_take_max_left cmp (s1, s2) start
           val (j1, j2) = split_count_take_max_left cmp (s1, s2) stop
 
-          (* val _ = print
-            ("block " ^ Int.toString b ^ " start " ^ Int.toString start
-             ^ " stop " ^ Int.toString stop ^ " i1 " ^ Int.toString i1 ^ " j1 "
-             ^ Int.toString j1 ^ " i2 " ^ Int.toString i2 ^ " j2 "
-             ^ Int.toString j2 ^ "\n") *)
-
           val piece1 = slice_idxs s1 (i1, j1)
           val piece2 = slice_idxs s2 (i2, j2)
           val piece_output = slice_idxs output (start, stop)
         in
-          StableMerge.writeMergeSerial cmp (piece1, piece2) piece_output
+          StableMerge.writeMerge cmp (piece1, piece2) piece_output
         end)
     end
 

--- a/lib/github.com/mpllang/mpllib/sources.mlton.mlb
+++ b/lib/github.com/mpllang/mpllib/sources.mlton.mlb
@@ -24,6 +24,8 @@ FuncSequence.sml
 BinarySearch.sml
 Merge.sml
 StableMerge.sml
+DoubleBinarySearch.sml
+StableMergeLowSpan.sml
 StableSort.sml
 Quicksort.sml
 Mergesort.sml

--- a/lib/github.com/mpllang/mpllib/sources.mpl.mlb
+++ b/lib/github.com/mpllang/mpllib/sources.mpl.mlb
@@ -24,6 +24,8 @@ FuncSequence.sml
 BinarySearch.sml
 Merge.sml
 StableMerge.sml
+DoubleBinarySearch.sml
+StableMergeLowSpan.sml
 StableSort.sml
 Quicksort.sml
 Mergesort.sml

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -4,6 +4,9 @@ stable-merge.mlton
 stable-merge-low-span
 stable-merge-low-span.mlton
 
+merge-bench
+merge-bench.mlton
+
 stable-sort
 stable-sort.mlton
 

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,6 +1,9 @@
 stable-merge
 stable-merge.mlton
 
+stable-merge-low-span
+stable-merge-low-span.mlton
+
 stable-sort
 stable-sort.mlton
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -2,7 +2,7 @@ MPL=mpl
 MLTON=mlton -codegen c
 FLAGS=-default-type int64 -default-type word64
 
-TESTS=stable-merge stable-sort delayed-seq chunk-treap read-write
+TESTS=stable-merge stable-sort stable-merge-low-span delayed-seq chunk-treap read-write
 
 MLTON_TESTS := $(addsuffix .mlton,$(TESTS))
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -2,7 +2,7 @@ MPL=mpl
 MLTON=mlton -codegen c
 FLAGS=-default-type int64 -default-type word64
 
-TESTS=stable-merge stable-sort stable-merge-low-span delayed-seq chunk-treap read-write
+TESTS=stable-merge stable-sort stable-merge-low-span delayed-seq chunk-treap read-write merge-bench 
 
 MLTON_TESTS := $(addsuffix .mlton,$(TESTS))
 

--- a/test/merge-bench.mlb
+++ b/test/merge-bench.mlb
@@ -1,0 +1,2 @@
+../lib/github.com/mpllang/mpllib/sources.$(COMP).mlb
+merge-bench.sml

--- a/test/merge-bench.sml
+++ b/test/merge-bench.sml
@@ -1,0 +1,30 @@
+structure CLA = CommandLineArgs
+val n = CLA.parseInt "size" 1000000
+val keys = CLA.parseInt "keys" 100
+val seed = CLA.parseInt "seed" 15210
+val impl = CLA.parseString "impl" "merge"
+
+val _ = print ("size " ^ Int.toString n ^ "\n")
+val _ = print ("keys " ^ Int.toString keys ^ "\n")
+val _ = print ("seed " ^ Int.toString seed ^ "\n")
+val _ = print ("impl " ^ impl ^ "\n")
+
+val merger =
+  case impl of
+    "merge" => Merge.writeMerge
+  | "stable-merge" => StableMerge.writeMerge
+  | "stable-merge-low-span" => StableMergeLowSpan.writeMerge
+  | _ =>
+      Util.die
+        ("unknown -impl " ^ impl
+         ^ "; valid options are: merge, stable-merge, stable-merge-low-span")
+
+val input1 = Mergesort.sort Int.compare
+  (Seq.tabulate (fn i => Util.hash (seed + i) mod keys) n)
+val input2 = Mergesort.sort Int.compare
+  (Seq.tabulate (fn i => Util.hash (seed + n + i) mod keys) n)
+val output = ArraySlice.full (ForkJoin.alloc (2 * n))
+
+val () = Benchmark.run impl (fn () =>
+  merger Int.compare (input1, input2) output)
+val _ = print (Util.summarizeArraySlice 10 Int.toString output ^ "\n")

--- a/test/merge-bench.sml
+++ b/test/merge-bench.sml
@@ -19,10 +19,12 @@ val merger =
         ("unknown -impl " ^ impl
          ^ "; valid options are: merge, stable-merge, stable-merge-low-span")
 
-val input1 = Mergesort.sort Int.compare
-  (Seq.tabulate (fn i => Util.hash (seed + i) mod keys) n)
-val input2 = Mergesort.sort Int.compare
-  (Seq.tabulate (fn i => Util.hash (seed + n + i) mod keys) n)
+val input1 = Seq.tabulate (fn i => Util.hash (seed + i) mod keys) n
+val () = Mergesort.sortInPlace Int.compare input1
+
+val input2 = Seq.tabulate (fn i => Util.hash (seed + n + i) mod keys) n
+val () = Mergesort.sortInPlace Int.compare input2
+
 val output = ArraySlice.full (ForkJoin.alloc (2 * n))
 
 val () = Benchmark.run impl (fn () =>

--- a/test/stable-merge-low-span.mlb
+++ b/test/stable-merge-low-span.mlb
@@ -1,0 +1,2 @@
+../lib/github.com/mpllang/mpllib/sources.$(COMP).mlb
+stable-merge-low-span.sml

--- a/test/stable-merge-low-span.sml
+++ b/test/stable-merge-low-span.sml
@@ -1,0 +1,75 @@
+structure CLA = CommandLineArgs
+val n = CLA.parseInt "size" 1000000
+val keys = CLA.parseInt "keys" 100
+val seed = CLA.parseInt "seed" 15210
+val numTests = CLA.parseInt "num-tests" 10
+val printTimes = CLA.parseFlag "print-times"
+
+val _ = print ("size " ^ Int.toString n ^ "\n")
+val _ = print ("keys " ^ Int.toString keys ^ "\n")
+val _ = print ("num-tests " ^ Int.toString numTests ^ "\n")
+val _ = print ("print-times? " ^ (if printTimes then "yes" else "no") ^ "\n")
+
+val _ =
+  if keys * 10 < n then
+    ()
+  else
+    print
+      ("WARNING: lots of unique keys. We recommend to using a small number \
+       \of keys relative to the number of elements, to encourage \
+       \duplicates and stress stability\n")
+
+fun err msg =
+  ( TextIO.output (TextIO.stdErr, "ERROR: " ^ msg ^ "\n")
+  ; OS.Process.exit OS.Process.failure
+  )
+
+(** NOTE: we'll ensure that the input is always two sorted sequences pasted
+  * together. This lets us test `merge` in isolation as though it were a
+  * general sort function.
+  *)
+fun janksort cmp s =
+  let
+    val left = Seq.take s n
+    val right = Seq.drop s n
+
+    val (result, tm) = Util.getTime (fn _ =>
+      StableMergeLowSpan.merge cmp (left, right))
+  in
+    if not printTimes then () else print ("time " ^ Time.fmt 4 tm ^ "s\n");
+
+    result
+  end
+
+structure CheckSort = CheckSort(val sort_func = janksort)
+
+fun checkone testNum seed =
+  let
+    val keys1 = Mergesort.sort Int.compare
+      (Seq.tabulate (fn i => Util.hash (seed + i) mod keys) n)
+    val keys2 = Mergesort.sort Int.compare
+      (Seq.tabulate (fn i => Util.hash (seed + n + i) mod keys) n)
+
+    val input = Seq.append (keys1, keys2)
+
+    val maybeError =
+      CheckSort.check
+        {compare = Int.compare, input = input, check_stable = true}
+
+    fun msg s =
+      "[" ^ Int.toString (testNum + 1) ^ "/" ^ Int.toString numTests ^ "]: " ^ s
+  in
+    case maybeError of
+      NONE => ()
+    | SOME e =>
+        case e of
+          CheckSort.LengthChange => err (msg "incorrect length")
+        | CheckSort.MissingElem _ => err (msg "missing element")
+        | CheckSort.Inversion _ => err (msg "not sorted")
+        | CheckSort.Unstable _ => err (msg "not stable");
+
+    print (msg "test passed" ^ "\n")
+  end
+
+val _ = Util.loop (0, numTests) seed (fn (seed, i) =>
+  (checkone i seed; Util.hash seed))


### PR DESCRIPTION
MPL implementation of a $O(\log n)$-span parallel merge, similar to the one I implemented for Futhark in https://github.com/diku-dk/sorts/pull/3. This is mostly just for fun, but could be educational.

This adds two new structures to the library:
- `DoubleBinarySearch`
- `StableMergeLowSpan`

The performance of `StableMergeLowSpan.{merge,writeMerge}` is very similar to both `Merge.{merge,writeMerge}` and `StableMerge.{merge,writeMerge}`. Perhaps slightly worse overall (a few percent slower?) but this could probably be optimized more.

Good demonstration that, in practice, poly-log span is generally sufficient, and shaving a log in the span usually isn't necessary.

I also added some command-line controllable tuning parameters.
- `-MPLLib_Merge_serialGrain ...`
- `-MPLLib_StableMerge_serialGrain ...`
- `-MPLLib_StableMergeLowSpan_blockSizeFactor ...`

...and, additional tests/benchmarking for the new implementation.